### PR TITLE
Continuation of 'Setting up Travis CI' - feature_travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+language: matlab
+
+matlab:
+  - R2020a
+  - latest  # Default MATLAB release on Travis CI
+
+env:
+  jobs:
+    - PYTHON_VERSION=3.7.9
+    - PYTHON_VERSION=3.8.6
+  global:
+    - PYENV_RELEASE=1.2.21
+
+jobs:
+  exclude:
+    - matlab: R2020a
+      env: PYTHON_VERSION=3.8.6
+
+before_install:
+  # Update pyenv
+  - pushd $(pyenv root)
+  - git fetch
+  - git checkout v${PYENV_RELEASE}
+  - popd
+
+install:  
+  # Install the python version and update pip
+  - pyenv install -v ${PYTHON_VERSION}
+  - pyenv global ${PYTHON_VERSION}
+  - python -m pip install --upgrade pip
+  
+  # Install MHKiT-Python
+  - python -m pip install mhkit
+  
+  # Install MHKiT-MATLAB
+  - python -m pip install -e .
+
+script:
+  # Show matlab and python version for the build
+  - matlab -batch "py.sys.setdlopenflags(int32(10)), version, pyversion, version('-blas')"
+  
+  # Installs mhkit toolbox in matlab, goes to the test folder, imports mhkit, 
+  # then runs the test script
+  - >
+    matlab -batch 
+    "py.sys.setdlopenflags(int32(10)),
+    matlab.addons.toolbox.installToolbox('mhkit.mltbx'),
+    cd mhkit/tests/,
+    import mhkit.*,
+    results = runTests(),
+    assertSuccess(results)"


### PR DESCRIPTION
This is a continuation of the "Setting up Travis" PR at [(https://github.com/MHKiT-Software/MHKiT-MATLAB/pull/41)]
This PR merges the 'feature_travisci' branch into the main MHKiT repository. The 'feature_travisci' branch is the latest commit and travis.yml file from the fork which had the setting up of Travis: [https://github.com/mfaltas-sandia/MHKiT-MATLAB]

This 'feature_travisci' branch has been tested and run on Travis CI with success and should be ready to merge.

