### PR TITLE
Install MHKiT-Python by cloning instead of pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ install:
   
   # Install MHKiT-Python
   - git clone https://github.com/MHKiT-Software/MHKiT-Python
-  - ls
   - cd MHKiT-Python
   - python -m pip install -e .
+  - cd ..
   
   # Install MHKiT-MATLAB
   - python -m pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ install:
   - python -m pip install --upgrade pip
   
   # Install MHKiT-Python
-  - python -m pip install mhkit
+  - git clone https://github.com/MHKiT-Software/MHKiT-Python
+  - cd mhkit-python
+  - python -m pip install -e .
   
   # Install MHKiT-MATLAB
   - python -m pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ install:
   
   # Install MHKiT-Python
   - git clone https://github.com/MHKiT-Software/MHKiT-Python
-  - cd mhkit-python
+  - ls
+  - cd MHKiT-Python
   - python -m pip install -e .
   
   # Install MHKiT-MATLAB


### PR DESCRIPTION
This PR installs MHKiT-Python by cloning the git repository as opposed to pip install. This allows for testing of functions that have been merged into MHKiT-Python repo but have not yet been tagged on pip.

Since I have run out of Travis credits on my fork, I am submitting a PR to test my build.