### PR TITLE
testing fix for h5py error

### DIFF
--- a/mhkit/river/performance/circular.m
+++ b/mhkit/river/performance/circular.m
@@ -19,9 +19,9 @@ function [D_E,projected_capture_area]=circular(diameter)
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%py.importlib.import_module('mhkit');
+py.importlib.import_module('from mhkit import river.performance as performance');
 
-result=py.mhkit.river.performance.circular(diameter);
+result=py.performance.circular(diameter);
 
 resultc=cell(result);
 D_E=resultc{1};

--- a/mhkit/river/performance/circular.m
+++ b/mhkit/river/performance/circular.m
@@ -19,7 +19,7 @@ function [D_E,projected_capture_area]=circular(diameter)
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-py.importlib.import_module('mhkit');
+%py.importlib.import_module('mhkit');
 
 result=py.mhkit.river.performance.circular(diameter);
 


### PR DESCRIPTION
removed mhkit load from circular function. If this works it can be applied to all other functions- but a solution will need to be found for the WPTO hindcast function 