### PR TITLE
Add Windows MATLAB-Actions Runners

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest] # windows-latest
+        os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     env:
@@ -31,21 +31,24 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install mhkit module (from source)
-        run: python -m pip install -e . "matplotlib<3.4.2"
+        run: python -m pip install -e .
         working-directory: ${{env.mhkit-python-dir}}
       - name: Install mhkit-python-utils module
         run: python -m pip install -e .
-      - name: Create MATLAB batch command
+      - name: Set MATLAB OutOfProcess Python execution mode
         shell: bash
-        run: echo "COMMAND=pyenv('ExecutionMode', 'OutOfProcess'), 
-                           version, 
-                           addpath(genpath('mhkit')), 
-                           import matlab.unittest.TestSuite, 
-                           import matlab.unittest.TestRunner, 
-                           testFolder = ['mhkit' filesep 'tests'], 
-                           suite = TestSuite.fromFolder(testFolder), 
-                           runner = TestRunner.withTextOutput,
-                           results = runner.run(suite), 
-                           assertSuccess(results)" >> "$GITHUB_ENV"
+        run: echo "pyenv('ExecutionMode', 'OutOfProcess')" > run.m
+        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' }}
+      - name: Add MATLAB test commands
+        shell: bash
+        run: echo "version, 
+                   addpath(genpath('mhkit')), 
+                   import matlab.unittest.TestSuite, 
+                   import matlab.unittest.TestRunner, 
+                   testFolder = ['mhkit' filesep 'tests'], 
+                   suite = TestSuite.fromFolder(testFolder), 
+                   runner = TestRunner.withTextOutput,
+                   results = runner.run(suite), 
+                   assertSuccess(results)" >> run.m
       - name: Install and test MHKiT-MATLAB
-        run: matlab -batch "${{ env.COMMAND }}"
+        run: matlab -batch "run"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,9 +2,9 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
 
 jobs:
   main:

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Thumbs.db
 *build
 *.prj
 .gitignore
+
+# Test results
+mhkit/tests/test_results/*

--- a/mhkit/tests/runTests.m
+++ b/mhkit/tests/runTests.m
@@ -18,7 +18,7 @@ function results = runTests()
     runner.addPlugin(plugin);
 
     % Add PDF
-    pdfFile = fullfile(testsFolder, 'test_results.pdf');
+    pdfFile = fullfile(htmlFolder, 'test_results.pdf');
     plugin = TestReportPlugin.producingPDF(pdfFile);
     runner.addPlugin(plugin);
 


### PR DESCRIPTION
This PR adds Windows runners for the CI unit tests. For the Windows based [MATLAB-Actions](https://github.com/matlab-actions/overview) runners, `OutOfProcess` execution mode for Python is not required to solve the HDF5 compatibility issue so the workflow was modified to only set `OutOfProcess` mode for the `macos` and `ubuntu` runners. Other changes are as follows:

* Following [this comment](https://github.com/MHKiT-Software/MHKiT-MATLAB/pull/80#issuecomment-1036145739), the version pin on matplotlib was removed as this was not a true fix.
* All outputs of the `runTests.m` script are now placed in a single folder which is ignored by git.