### PR TITLE
Add older matlab release test case to CI

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master, develop ]
   pull_request:
     branches: [ master, develop ]
-  workflow dispatch:
+  workflow_dispatch:
 
 jobs:
   main:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,7 +1,7 @@
 name: Unit Tests
 
 on:
-  # push:
+  push:
   #   branches: [ master, develop ]
   # pull_request:
   #   branches: [ master, develop ]

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: [3.8, 3.9]
         mat_release: [latest]
         include:
-          - os: windows-latest
+          - os: ubuntu-latest
             mat_release: R2020b
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master, develop ]
   pull_request:
     branches: [ master, develop ]
+  workflow dispatch:
 
 jobs:
   main:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,10 +1,10 @@
 name: Unit Tests
 
 on:
-  push:
-    branches: [ master, develop ]
-  pull_request:
-    branches: [ master, develop ]
+  # push:
+  #   branches: [ master, develop ]
+  # pull_request:
+  #   branches: [ master, develop ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,10 +2,9 @@ name: Unit Tests
 
 on:
   push:
-  #   branches: [ master, develop ]
-  # pull_request:
-  #   branches: [ master, develop ]
-  workflow_dispatch:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
 
 jobs:
   main:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: [3.8, 3.9]
-        release: latest
+        mat_release: latest
         include:
           - os: windows-latest
-            release: R2020b
+            mat_release: R2020b
     runs-on: ${{ matrix.os }}
     env:
       mhkit-python-dir: 'MHKiT-Python'
@@ -32,7 +32,7 @@ jobs:
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v1
         with:
-          release: ${{ matrix.release }}
+          release: ${{ matrix.mat_release }}
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,6 +13,10 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: [3.8, 3.9]
+        release: latest
+        include:
+          - os: windows-latest
+            release: R2020b
     runs-on: ${{ matrix.os }}
     env:
       mhkit-python-dir: 'MHKiT-Python'
@@ -26,6 +30,8 @@ jobs:
           path: ${{env.mhkit-python-dir}}
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v1
+        with:
+          release: ${{ matrix.release }}
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: [3.8, 3.9]
-        mat_release: latest
+        mat_release: [latest]
         include:
           - os: windows-latest
             mat_release: R2020b


### PR DESCRIPTION
The purpose of this PR is to address issue #95. The unit test Github Actions has been updated to include an extra test case `[ubuntu-latest, R2020b]` so that we can test our code against older releases of Matlab that we claim are still compatible with our code. The workflow was tested on my fork against the current dev branch and all tests passed. Below are some reference sites used to make the edits to the workflow. 

https://github.com/matlab-actions/setup-matlab/#set-up-matlab
https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs