### PR TITLE
Add Code Compatibility Reporting

### DIFF
--- a/.github/workflows/code_compatibility_report.yml
+++ b/.github/workflows/code_compatibility_report.yml
@@ -22,10 +22,6 @@ jobs:
       - name: Check out MHKiT-MATLAB
         uses: actions/checkout@v4
 
-      - name: Setup MATLAB Path on Ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: echo "LD_PRELOAD=/lib/x86_64-linux-gnu/libstdc++.so.6" >> "$GITHUB_ENV"
-
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v2-beta
         with:
@@ -37,17 +33,11 @@ jobs:
           addpath(genpath('mhkit')),
           results = runCodeCompatibilityReport()" >> run.m
 
-      - name: Output run.m
+      - name: Echo runner for code compatibility report
         shell: bash
         run: cat run.m
 
-      # This is a good idea but does not work because you cannot explicitly set the python execution mode
-      #   - name: Run MHKiT-MATLAB Unit Tests
-      #     uses: matlab-actions/run-tests@v1
-      #     with:
-      #         select-by-folder: mhkit/tests
-
-      - name: Run MATLAB Unit Tests
+      - name: Run code compatibility report
         uses: matlab-actions/run-command@v1
         with:
           command: run

--- a/.github/workflows/code_compatibility_report.yml
+++ b/.github/workflows/code_compatibility_report.yml
@@ -1,0 +1,54 @@
+name: MHKiT-MATLAB Code Compatibility Test
+
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master, develop]
+
+jobs:
+  main:
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        python-version: [3.8, 3.9, "3.10", 3.11]
+        matlab-version: [R2021b, R2022a, R2022b, R2023a, R2023b]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Check out MHKiT-MATLAB
+        uses: actions/checkout@v4
+
+      - name: Setup MATLAB Path on Ubuntu
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: echo "LD_PRELOAD=/lib/x86_64-linux-gnu/libstdc++.so.6" >> "$GITHUB_ENV"
+
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v2-beta
+        with:
+          release: ${{ matrix.matlab-version }}
+
+      - name: Build file to run code compatability report
+        shell: bash
+        run: echo "version,
+          addpath(genpath('mhkit')),
+          results = runCodeCompatibilityReport()" >> run.m
+
+      - name: Output run.m
+        shell: bash
+        run: cat run.m
+
+      # This is a good idea but does not work because you cannot explicitly set the python execution mode
+      #   - name: Run MHKiT-MATLAB Unit Tests
+      #     uses: matlab-actions/run-tests@v1
+      #     with:
+      #         select-by-folder: mhkit/tests
+
+      - name: Run MATLAB Unit Tests
+        uses: matlab-actions/run-command@v1
+        with:
+          command: run
+          startup-options: -noFigureWindows

--- a/mhkit/tests/runCodeCompatibilityReport.m
+++ b/mhkit/tests/runCodeCompatibilityReport.m
@@ -1,0 +1,38 @@
+function results = runCodeCompatibilityReport()
+    % Find source code folder
+    this_filename = mfilename('fullpath');
+    this_folder = fileparts(this_filename);
+    sourceCodeFolder = fileparts(this_folder);
+
+    % Generate MATLAB code compatibility report
+    r = analyzeCodeCompatibility(sourceCodeFolder, 'IncludeSubfolders', true);
+
+    % Print code compatability report
+    display("MHKiT MATLAB Code Compatibility Report");
+    display(r.Recommendations);
+
+    % Search for error string in the `Severity` column. If found exit with status code 1 to indicate to the test runner that ther
+    error_string = 'Error';
+    severity_array = r.Recommendations.Severity;
+
+    % Convert categorical array to cell array of strings
+    severity_cell_array = cellstr(severity_array);
+
+    % Sanitize error string
+    sanitized_error_string = lower(strtrim(error_string));
+
+    % Sanitize each element in the array using cellfun
+    sanitized_severity_array = cellfun(@(x) lower(strtrim(x)), severity_cell_array, 'UniformOutput', false);
+
+    if any(strcmp(sanitized_severity_array, sanitized_error_string))
+        disp(['Code Compatability Failure: Found "', error_string, '". in the MHKiT-MATLAB code compatability report. See above output for details.']);
+        exit(1);
+    else
+        disp('Success: MHKiT-MATLAB Code Compatability Analysis did not find errors!');
+        exit(0);
+    end
+
+
+    results = runCodeCompatibilityReport();
+
+end


### PR DESCRIPTION
Addressing issue #67. 

Use [MATLAB's built in `analyzeCodeCompatibility`](https://www.mathworks.com/help/matlab/ref/codecompatibilityreport.html) function to run a code compatibility report. The output table provides insight into code that is not compatible with newer versions of MATLAB.

This runs the code compatibility report on the entire `mhkit` directory, and parses output from the code compatibility report. If "Error" is found is the Severity column, exit status 1 is returned.

The information in this output is relevant to core developers, but not for feature developers. Failing the code compatibility analysis should not make the test fail. We plan to add a separate GitHub action capture the output, but this action is mostly for visibility. 

Remaining Tasks

* [X] Add separate GitHub Action to run this test

As of this PR there are only "Warnings" and "Info" in the code compatibility report. These should be addressed, but that work falls outside the scope of this PR.

Below is the condensed output from this report:

| Identifier    | Severity | Documentation                     | Suppression | File                                                       | LineNumber | ColumnRange |
| ---           | ---      | ---                               | ---         | ---                                                        | ---        | ---         |
| COLMP         | Warning  | [Details](#colmp-details)         | none        | mhkit/tidal/graphics/plot_joint_probability_distribution.m | 169        | 10    17    |
| COLMP         | Warning  | [Details](#colmp-details)         | none        | mhkit/tidal/graphics/plot_rose.m                           | 104        | 17    24    |
| COLMP         | Warning  | [Details](#colmp-details)         | none        | mhkit/wave/graphics/plot_matrix.m                          | 38         | 17    19    |
| DATNM         | Info     | [Details](#datnm-details)         | none        | mhkit/dolfyn/io/read_rdi.m                                 | 626        | 13    19    |
| DATNM         | Info     | [Details](#datnm-details)         | none        | mhkit/dolfyn/io/read_rdi.m                                 | 635        | 13    19    |
| DATNM         | Info     | [Details](#datnm-details)         | none        | mhkit/dolfyn/io/read_rdi.m                                 | 648        | 13    19    |
| DATNM         | Info     | [Details](#datnm-details)         | none        | mhkit/dolfyn/io/read_rdi.m                                 | 680        | 17    23    |
| DATNM         | Info     | [Details](#datnm-details)         | none        | mhkit/tests/QC_Test.m                                      | 45         | 24    30    |
| DATNM         | Info     | [Details](#datnm-details)         | none        | mhkit/tests/QC_Test.m                                      | 46         | 24    30    |
| DATNM         | Info     | [Details](#datnm-details)         | none        | mhkit/tests/QC_Test.m                                      | 71         | 24    30    |
| DATNM         | Info     | [Details](#datnm-details)         | none        | mhkit/tests/QC_Test.m                                      | 72         | 24    30    |
| DATNM         | Info     | [Details](#datnm-details)         | none        | mhkit/tests/QC_Test.m                                      | 162        | 28    34    |
| DATNM         | Info     | [Details](#datnm-details)         | none        | mhkit/tests/QC_Test.m                                      | 162        | 53    59    |
| DATNM         | Info     | [Details](#datnm-details)         | none        | mhkit/tests/River_TestIO.m                                 | 20         | 51    57    |
| DATST         | Info     | [Details](#datst-details)         | none        | mhkit/dolfyn/io/read_rdi.m                                 | 626        | 21    27    |
| DATST         | Info     | [Details](#datst-details)         | none        | mhkit/dolfyn/io/read_rdi.m                                 | 635        | 21    27    |
| DATST         | Info     | [Details](#datst-details)         | none        | mhkit/dolfyn/io/read_rdi.m                                 | 648        | 21    27    |
| DATST         | Info     | [Details](#datst-details)         | none        | mhkit/dolfyn/io/read_rdi.m                                 | 680        | 25    31    |
| DATST         | Info     | [Details](#datst-details)         | none        | mhkit/tests/River_TestIO.m                                 | 19         | 30    36    |
| DATST         | Info     | [Details](#datst-details)         | none        | mhkit/tests/River_TestIO.m                                 | 20         | 25    31    |
| DATST         | Info     | [Details](#datst-details)         | none        | mhkit/tidal/io/request_noaa_data.m                         | 80         | 18    24    |
| DATST         | Info     | [Details](#datst-details)         | none        | mhkit/tidal/io/request_noaa_data.m                         | 81         | 20    26    |
| DATST         | Info     | [Details](#datst-details)         | none        | mhkit/wave/graphics/plot_compendium.m                      | 36         | 5     11    |
| DATST         | Info     | [Details](#datst-details)         | none        | mhkit/wave/graphics/plot_compendium.m                      | 37         | 5     11    |
| DISPLAYPROG   | Info     | [Details](#disparog-details)      | none        | mhkit/tests/runCodeCompatibilityReport.m                   | 11         | 5     11    |
| GETFMT        | Info     | [Details](#getfmt-details)        | none        | mhkit/tests/Dolfyn_TestIO.m                                | 290        | 28    35    |
| GETFMT        | Info     | [Details](#getfmt-details)        | none        | mhkit/tests/Dolfyn_Test_Rotate.m                           | 395        | 28    35    |
| HISTC         | Info     | [Details](#histc-details)         | none        | mhkit/dolfyn/io/read_signature.m                           | 1514       | 22    26    |
| IDISVARLOW    | Warning  | [Details](#idisvarlow-details)    | none        | mhkit/river/resource/Froude_number.m                       | 28         | 8     14    |
| LEGPVPAIR     | Warning  | [Details](#legpvpair-details)     | none        | mhkit/wave/graphics/plot_chakrabarti.m                     | 71         | 40    51    |
| VERLESSMATLAB | Info     | [Details](#verlessmatlab-details) | none        | mhkit/dolfyn/rotate/tensorproduct_core.m                   | 6          | 5     15    |

### Details:

#### COLMP Details (Warning):
- In R2019a and previous releases, the default colormap size is 64.
- Starting in R2019b, colormaps have 256 colors by default.
- If your code depends on a colormap having 64 colors, specify the number of colors when querying the colormap.
- For example, `parula(64)` queries the 64-color parula colormap.

#### DATNM Details (Info):
- `'datenum'` is not recommended.
- With appropriate code changes, use `'datetime'` instead.

#### DATST Details (Info):
- `'datestr'` is not recommended.
- With appropriate code changes, use `'datetime'` instead.

#### DISPLAYPROG Details (Info):
- Programmatic use of `DISPLAY` is not recommended.
- Use `DISP` or `FPRINTF` instead.

#### GETFMT Details (Info):
- Using `get` for retrieving values of numeric display format is not recommended.
- With appropriate code changes, use `'settings'` object instead.

#### HISTC Details (Info):
- `'histc'` is not recommended.
- With appropriate code changes, use `'histcounts'` instead.

#### IDISVARLOW Details (Warning):
- To avoid a potential conflict with functions on the path, explicitly define the variable before indexing into it.

#### LEGPVPAIR Details (Warning):
- `'legend'` has changed and might interpret the name of an argument as a legend property instead of a label.
- To include a label with the same name as a legend property, specify the labels using a cell array or string array.
- Refer to the documentation for a list of affected property names.

#### VERLESSMATLAB Details (Info):
- `verLessThan('matlab', ...)` is not recommended.
- With appropriate code changes, use `'isMATLABReleaseOlderThan'` instead.
