### PR TITLE
Fix: Specify MHKiT-Python version for tests and users

### DIFF
--- a/.github/workflows/code_compatibility_report.yml
+++ b/.github/workflows/code_compatibility_report.yml
@@ -12,7 +12,8 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [macos-13, ubuntu-latest, windows-latest]
+        # os: [macos-13, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: [3.8, 3.9, "3.10", 3.11]
         matlab-version: [R2021b, R2022a, R2022b, R2023a, R2023b]
 

--- a/.github/workflows/code_compatibility_report.yml
+++ b/.github/workflows/code_compatibility_report.yml
@@ -38,7 +38,7 @@ jobs:
         run: cat run.m
 
       - name: Run code compatibility report
-        uses: matlab-actions/run-command@v1
+        uses: matlab-actions/run-command@v2
         with:
           command: run
           startup-options: -noFigureWindows

--- a/.github/workflows/code_compatibility_report.yml
+++ b/.github/workflows/code_compatibility_report.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-13, ubuntu-latest, windows-latest]
         python-version: [3.8, 3.9, "3.10", 3.11]
         matlab-version: [R2021b, R2022a, R2022b, R2023a, R2023b]
 

--- a/.github/workflows/code_compatibility_report.yml
+++ b/.github/workflows/code_compatibility_report.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v2-beta
+        uses: matlab-actions/setup-matlab@v2
         with:
           release: ${{ matrix.matlab-version }}
 

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -280,7 +280,6 @@ jobs:
           pip install mhkit==$MHKIT_PYTHON_VERSION
 
       - name: pip upgrade netcdf4
-        working-directory: ${{env.mhkit-python-dir}}
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -42,11 +42,11 @@ jobs:
       - name: Check out MHKiT-MATLAB
         uses: actions/checkout@v4
 
-      - name: Check out MHKiT-Python
-        uses: actions/checkout@v4
-        with:
-          repository: "MHKiT-Software/MHKiT-Python"
-          path: ${{env.mhkit-python-dir}}
+      # - name: Check out MHKiT-Python
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: "MHKiT-Software/MHKiT-Python"
+      #     path: ${{env.mhkit-python-dir}}
 
       # - name: pip install mhkit module from source
       #   shell: bash -l {0}
@@ -191,11 +191,11 @@ jobs:
       - name: Check out MHKiT-MATLAB
         uses: actions/checkout@v4
 
-      - name: Check out MHKiT-Python
-        uses: actions/checkout@v4
-        with:
-          repository: "MHKiT-Software/MHKiT-Python"
-          path: ${{env.mhkit-python-dir}}
+      # - name: Check out MHKiT-Python
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: "MHKiT-Software/MHKiT-Python"
+      #     path: ${{env.mhkit-python-dir}}
 
       - name: Install & Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -20,6 +20,7 @@ jobs:
 
     env:
       mhkit-python-dir: "MHKiT-Python"
+      MHKIT_PYTHON_VERSION: '0.7.0'
     steps:
       - name: Install & Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
@@ -47,12 +48,18 @@ jobs:
           repository: "MHKiT-Software/MHKiT-Python"
           path: ${{env.mhkit-python-dir}}
 
-      - name: pip install mhkit module from source
+      # - name: pip install mhkit module from source
+      #   shell: bash -l {0}
+      #   run: |
+      #     conda activate mhkit_conda_env
+      #     pip install -e .
+      #   working-directory: ${{env.mhkit-python-dir}}
+
+      - name: pip install mhkit from pypi
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
-          pip install -e .
-        working-directory: ${{env.mhkit-python-dir}}
+          pip install mhkit==$MHKIT_PYTHON_VERSION
 
       - name: pip install mhkit-python-utils module from source
         shell: bash -l {0}
@@ -122,6 +129,7 @@ jobs:
         python-version: [3.8, 3.9, "3.10", 3.11]
         # Note: It is preferred to use an actual release name as opposed to 'latest'
         matlab-version: [R2021b, R2022a, R2022b, R2023a, R2023b, R2024a]
+        mhkit-python-version: ["0.7.0"]
         exclude:
           - python-version: "3.10" # cache_population job
             matlab-version: R2022b
@@ -178,6 +186,7 @@ jobs:
 
     env:
       mhkit-python-dir: "MHKiT-Python"
+      MHKIT_PYTHON_VERSION: ${{  matrix.mhkit-python-version }}
     steps:
       - name: Check out MHKiT-MATLAB
         uses: actions/checkout@v4
@@ -255,13 +264,20 @@ jobs:
           conda activate mhkit_conda_env
           python --version
 
-      - name: pip install mhkit module from source
-        working-directory: ${{env.mhkit-python-dir}}
+      # - name: pip install mhkit module from source
+      #   working-directory: ${{env.mhkit-python-dir}}
+      #   shell: bash -l {0}
+      #   run: |
+      #     conda activate mhkit_conda_env
+      #     export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
+      #     pip install -e .
+
+      - name: pip install mhkit from pypi
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
           export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
-          pip install -e .
+          pip install mhkit==$MHKIT_PYTHON_VERSION
 
       - name: pip upgrade netcdf4
         working-directory: ${{env.mhkit-python-dir}}

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -47,6 +47,7 @@ jobs:
       # - name: pip install mhkit from source
       - name: pip install mhkit from pypi
         # working-directory: ${{env.mhkit-python-dir}}
+        shell: bash -l {0}
         run: |
           "conda activate mhkit_conda_env && pip install mhkit==$MHKIT-PYTHON-VERSION"
 
@@ -167,16 +168,19 @@ jobs:
 
       # This is necessary to fix any issues with netcdf4 and hdf5 headers
       - name: "Conda install netcdf4, hdf5"
+        shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
           conda install netcdf4 hdf5
 
       - name: Output python executable
+        shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
           python -c "import sys; print(sys.executable)"
 
       - name: Print Python Version
+        shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
           python --version
@@ -192,6 +196,7 @@ jobs:
 
       # - name: pip install mhkit from source
       - name: pip install mhkit from pypi
+        shell: bash -l {0}
         # working-directory: ${{env.mhkit-python-dir}}
         run: |
           "conda activate mhkit_conda_env && pip install mhkit==$MHKIT-PYTHON-VERSION"
@@ -203,11 +208,13 @@ jobs:
       #     pip3 install -e .
 
       - name: pip install mhkit-python-utils module from source
+        shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
           pip3 install -e .
 
       - name: List installed pip modules
+        shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
           pip3 freeze

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -48,8 +48,7 @@ jobs:
       - name: pip install mhkit from pypi
         # working-directory: ${{env.mhkit-python-dir}}
         run: |
-          conda activate mhkit_conda_env
-          pip install mhkit==$MHKIT-PYTHON-VERSION
+          "conda activate mhkit_conda_env && pip install mhkit==$MHKIT-PYTHON-VERSION"
 
       - name: pip install mhkit-python-utils module from source
         run: |
@@ -195,8 +194,7 @@ jobs:
       - name: pip install mhkit from pypi
         # working-directory: ${{env.mhkit-python-dir}}
         run: |
-          conda activate mhkit_conda_env
-          pip install mhkit==$MHKIT-PYTHON-VERSION
+          "conda activate mhkit_conda_env && pip install mhkit==$MHKIT-PYTHON-VERSION"
 
       # - name: pip install mhkit from source
       #   working-directory: ${{env.mhkit-python-dir}}

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     env:
       mhkit-python-dir: "MHKiT-Python"
-      MHKIT-PYTHON-VERSION: 0.7
+      MHKIT_PYTHON_VERSION: 0.7
     steps:
       - name: Install/Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
@@ -49,7 +49,7 @@ jobs:
         # working-directory: ${{env.mhkit-python-dir}}
         shell: bash -l {0}
         run: |
-          "conda activate mhkit_conda_env && pip install mhkit==$MHKIT-PYTHON-VERSION"
+          "conda activate mhkit_conda_env && pip install mhkit==$MHKIT_PYTHON_VERSION"
 
       - name: pip install mhkit-python-utils module from source
         run: |
@@ -155,7 +155,7 @@ jobs:
 
     env:
       mhkit-python-dir: "MHKiT-Python"
-      MHKIT-PYTHON-VERSION: ${{  matrix.mhkit-python-version }}
+      MHKIT_PYTHON_VERSION: ${{  matrix.mhkit-python-version }}
     steps:
       - name: Install/Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
@@ -199,7 +199,7 @@ jobs:
         shell: bash -l {0}
         # working-directory: ${{env.mhkit-python-dir}}
         run: |
-          "conda activate mhkit_conda_env && pip install mhkit==$MHKIT-PYTHON-VERSION"
+          "conda activate mhkit_conda_env && pip install mhkit==$MHKIT_PYTHON_VERSION"
 
       # - name: pip install mhkit from source
       #   working-directory: ${{env.mhkit-python-dir}}

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     env:
       mhkit-python-dir: "MHKiT-Python"
-      MHKIT_PYTHON_VERSION: 0.7
+      MHKIT_PYTHON_VERSION: '0.7.0'
     steps:
       - name: Install/Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
@@ -49,7 +49,8 @@ jobs:
         # working-directory: ${{env.mhkit-python-dir}}
         shell: bash -l {0}
         run: |
-          "conda activate mhkit_conda_env && pip install mhkit==$MHKIT_PYTHON_VERSION"
+          "conda activate mhkit_conda_env"
+          "pip install mhkit==$MHKIT_PYTHON_VERSION"
 
       - name: pip install mhkit-python-utils module from source
         run: |
@@ -119,7 +120,7 @@ jobs:
         os: [windows-latest]
         python-version: [3.8, 3.9, "3.10", 3.11]
         matlab-version: [R2021b, R2022a, R2022b, R2023a, R2023b, R2024a]
-        mhkit-python-version: ["0.7"]
+        mhkit-python-version: ["0.7.0"]
         exclude:
           - matlab-version: R2022a
             python-version: 3.9
@@ -199,7 +200,8 @@ jobs:
         shell: bash -l {0}
         # working-directory: ${{env.mhkit-python-dir}}
         run: |
-          "conda activate mhkit_conda_env && pip install mhkit==$MHKIT_PYTHON_VERSION"
+          "conda activate mhkit_conda_env"
+          "pip install mhkit==$MHKIT_PYTHON_VERSION"
 
       # - name: pip install mhkit from source
       #   working-directory: ${{env.mhkit-python-dir}}

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -45,8 +45,12 @@ jobs:
       #     path: ${{env.mhkit-python-dir}}
 
       # - name: pip install mhkit from source
+      #   working-directory: ${{env.mhkit-python-dir}}
+      #   run: |
+      #     conda activate mhkit_conda_env
+      #     pip3 install -e .
+
       - name: pip install mhkit from pypi
-        # working-directory: ${{env.mhkit-python-dir}}
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
@@ -196,18 +200,16 @@ jobs:
       #     path: ${{env.mhkit-python-dir}}
 
       # - name: pip install mhkit from source
-      - name: pip install mhkit from pypi
-        shell: bash -l {0}
-        # working-directory: ${{env.mhkit-python-dir}}
-        run: |
-          conda activate mhkit_conda_env
-          pip install mhkit==$MHKIT_PYTHON_VERSION
-
-      # - name: pip install mhkit from source
       #   working-directory: ${{env.mhkit-python-dir}}
       #   run: |
       #     conda activate mhkit_conda_env
       #     pip3 install -e .
+
+      - name: pip install mhkit from pypi
+        shell: bash -l {0}
+        run: |
+          conda activate mhkit_conda_env
+          pip install mhkit==$MHKIT_PYTHON_VERSION
 
       - name: pip install mhkit-python-utils module from source
         shell: bash -l {0}
@@ -254,7 +256,7 @@ jobs:
           conda activate mhkit_conda_env
           printf "getenv('path')\nsetenv('path', ['%s;', getenv('path')])\ngetenv('path')\n" $(python -c "import sys; import os; print(os.path.dirname(sys.executable))") >> run.m
 
-      # OutOfProcess works reliably on linux and macos, on Windows
+      # OutOfProcess works reliably on linux, macos, and windows
       - name: Configure MATLAB pyenv Version and ExecutionMode
         shell: bash -l {0}
         run: |

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -49,8 +49,8 @@ jobs:
         # working-directory: ${{env.mhkit-python-dir}}
         shell: bash -l {0}
         run: |
-          "conda activate mhkit_conda_env"
-          "pip install mhkit==$MHKIT_PYTHON_VERSION"
+          conda activate mhkit_conda_env
+          pip install mhkit==$MHKIT_PYTHON_VERSION
 
       - name: pip install mhkit-python-utils module from source
         run: |
@@ -200,8 +200,8 @@ jobs:
         shell: bash -l {0}
         # working-directory: ${{env.mhkit-python-dir}}
         run: |
-          "conda activate mhkit_conda_env"
-          "pip install mhkit==$MHKIT_PYTHON_VERSION"
+          conda activate mhkit_conda_env
+          pip install mhkit==$MHKIT_PYTHON_VERSION
 
       # - name: pip install mhkit from source
       #   working-directory: ${{env.mhkit-python-dir}}

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -18,6 +18,7 @@ jobs:
 
     env:
       mhkit-python-dir: "MHKiT-Python"
+      MHKIT-PYTHON-VERSION: 0.7
     steps:
       - name: Install/Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
@@ -37,17 +38,18 @@ jobs:
       - name: Check out MHKiT-MATLAB
         uses: actions/checkout@v4
 
-      - name: Check out MHKiT-Python
-        uses: actions/checkout@v4
-        with:
-          repository: "MHKiT-Software/MHKiT-Python"
-          path: ${{env.mhkit-python-dir}}
+      # - name: Check out MHKiT-Python
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: "MHKiT-Software/MHKiT-Python"
+      #     path: ${{env.mhkit-python-dir}}
 
-      - name: pip install mhkit from source
-        working-directory: ${{env.mhkit-python-dir}}
+      # - name: pip install mhkit from source
+      - name: pip install mhkit from pypi
+        # working-directory: ${{env.mhkit-python-dir}}
         run: |
           conda activate mhkit_conda_env
-          pip install -e .
+          pip install mhkit==$MHKIT-PYTHON-VERSION
 
       - name: pip install mhkit-python-utils module from source
         run: |
@@ -117,6 +119,7 @@ jobs:
         os: [windows-latest]
         python-version: [3.8, 3.9, "3.10", 3.11]
         matlab-version: [R2021b, R2022a, R2022b, R2023a, R2023b, R2024a]
+        mhkit-python-version: ["0.7"]
         exclude:
           - matlab-version: R2022a
             python-version: 3.9
@@ -152,6 +155,7 @@ jobs:
 
     env:
       mhkit-python-dir: "MHKiT-Python"
+      MHKIT-PYTHON-VERSION: ${{  matrix.mhkit-python-version }}
     steps:
       - name: Install/Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
@@ -181,17 +185,24 @@ jobs:
       - name: Check out MHKiT-MATLAB
         uses: actions/checkout@v4
 
-      - name: Check out MHKiT-Python
-        uses: actions/checkout@v4
-        with:
-          repository: "MHKiT-Software/MHKiT-Python"
-          path: ${{env.mhkit-python-dir}}
+      # - name: Check out MHKiT-Python
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: "MHKiT-Software/MHKiT-Python"
+      #     path: ${{env.mhkit-python-dir}}
 
-      - name: pip install mhkit from source
-        working-directory: ${{env.mhkit-python-dir}}
+      # - name: pip install mhkit from source
+      - name: pip install mhkit from pypi
+        # working-directory: ${{env.mhkit-python-dir}}
         run: |
           conda activate mhkit_conda_env
-          pip3 install -e .
+          pip install mhkit==$MHKIT-PYTHON-VERSION
+
+      # - name: pip install mhkit from source
+      #   working-directory: ${{env.mhkit-python-dir}}
+      #   run: |
+      #     conda activate mhkit_conda_env
+      #     pip3 install -e .
 
       - name: pip install mhkit-python-utils module from source
         run: |

--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@ See the [documentation](https://mhkit-software.github.io/MHKiT/) for more inform
 
 ## Installation
 
+**NOTE:** MHKiT-MATLAB now requires the user to install a specific version of MHKiT-Python,
+currently version `0.7.0`. You can achieve this by executing the following commands in the Anaconda
+environment where MHKiT-Python is installed:
+
+1. Uninstall the current version of MHKiT-Python:
+    ```bash
+    pip uninstall mhkit
+    ```
+
+2. Install MHKiT-Python version `0.7.0`:
+    ```bash
+    pip install mhkit==0.7.0
+    ```
+
+3. Verify the MHKiT-Python version:
+    ```bash
+    python -c "import mhkit; print(mhkit.__version__)"
+    ```
+
+
 ### Software Requirements
 
 MHKiT-MATLAB utilizes Python functions from MHKiT-Python and requires the user to have


### PR DESCRIPTION
The v0.8.0 release of MHKiT-Python introduces incompatibilities in MHKiT-MATLAB. Specific failing tests are detailed in #130.

This PR specifies the MHKiT-Python version in the documentation and tests. This is a temporary solution until we reach parity with MHKiT Python. At that time it will be useful to test against the `develop` branch, which should help us catch these types of bugs earlier in the development cycle.