### PR TITLE
Correctly map `Hs` argument in `jonswap_spectrum`

### DIFF
--- a/mhkit/tests/Wave_TestResourceSpectrum.m
+++ b/mhkit/tests/Wave_TestResourceSpectrum.m
@@ -113,6 +113,21 @@ classdef Wave_TestResourceSpectrum < matlab.unittest.TestCase
             assertLessThan(testCase,errorHm0, 0.01);
             assertLessThan(testCase,errorTp0, 0.01);
         end
+
+        function test_jonswap_spectrum_gamma(testCase)
+            Obj.f = 0.1/(2*pi):0.01/(2*pi):3.5/(2*pi);
+            Obj.Tp = 8;
+            Obj.Hs = 2.5;
+            Obj.gamma = 2.0
+
+            S = jonswap_spectrum(Obj.f, Obj.Tp, Obj.Hs, Obj.gamma);
+            Hm0 = significant_wave_height(S);
+            Tp0 = peak_period(S);
+            errorHm0 = abs(Obj.Tp - Tp0)/Obj.Tp;
+            errorTp0 = abs(Obj.Hs - Hm0)/Obj.Hs;
+            assertLessThan(testCase,errorHm0, 0.01);
+            assertLessThan(testCase,errorTp0, 0.01);
+        end
         
         function test_plot_spectrum(testCase)
             Obj.f = 0.1/(2*pi):0.01/(2*pi):3.5/(2*pi);

--- a/mhkit/wave/resource/jonswap_spectrum.m
+++ b/mhkit/wave/resource/jonswap_spectrum.m
@@ -47,7 +47,7 @@ end
 if nargin == 3
         S_py=py.mhkit.wave.resource.jonswap_spectrum(frequency,Tp,Hs);
 elseif nargin == 4 
-        S_py=py.mhkit.wave.resource.jonswap_spectrum(frequency,Tp,varargin{1},pyargs('gamma',varargin{1}));
+        S_py=py.mhkit.wave.resource.jonswap_spectrum(frequency, Tp, Hs, pyargs('gamma', varargin{1}));
 end
 
 S.spectrum=double(py.array.array('d',py.numpy.nditer(S_py.values))).';


### PR DESCRIPTION
This fixes a bug, described in #132, where the `Hs` argument input into the `jonswap_spectrum` function is not properly mapped to the corresponding `mhkit.wave.resource.jonswap_spectrum` function. This maps `Hs` into the 3rd argument of `jonswap_spectrum` when the gamma parameter is passed.