### PR TITLE
Fix Failing Actions

### DIFF
--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -224,7 +224,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
-          conda install numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4
+          conda install numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4 openssl
           # conda install netcdf4 hdf5
           # export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
 

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
-          conda install numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4
+          conda install numpy==1.26.4 cython pip pytest hdf5 libnetcdf cftime netcdf4
           # conda install netcdf4 hdf5
           # export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
 
@@ -224,14 +224,14 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
-          conda install numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4
+          conda install numpy==1.26.4 cython pip pytest hdf5 libnetcdf cftime netcdf4
           # conda install netcdf4 hdf5
           # export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
 
       # - name: Setup Python ${{ matrix.python-version }}
         # shell: bash -l {0}
         # run: |
-        #   conda create --name mhkit_conda_env python=${{ matrix.python-version }} numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4 --strict-channel-priority
+        #   conda create --name mhkit_conda_env python=${{ matrix.python-version }} numpy==1.26.4 cython pip pytest hdf5 libnetcdf cftime netcdf4 --strict-channel-priority
         #   conda activate mhkit_conda_env
         #   export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
         #   pip install -e . --no-deps --force-reinstall

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -224,7 +224,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
-          conda install numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4
+          conda install numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4 openssl=3.0.0
           # conda install netcdf4 hdf5
           # export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
 
@@ -355,9 +355,10 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
-          OPENSSL_LIB_PATH=$(brew --prefix openssl)/lib
+          # OPENSSL_LIB_PATH=$(brew --prefix openssl)/lib
           CONDA_LIB_PATH=$(python -c "import sys; import os; print(os.path.join(os.path.dirname(sys.executable), 'lib'))")
-          export DYLD_LIBRARY_PATH="$CONDA_LIB_PATH:$OPENSSL_LIB_PATH:$DYLD_LIBRARY_PATH"
+          # export DYLD_LIBRARY_PATH="$CONDA_LIB_PATH:$OPENSSL_LIB_PATH:$DYLD_LIBRARY_PATH"
+          export DYLD_LIBRARY_PATH="$CONDA_LIB_PATH:$DYLD_LIBRARY_PATH"
           echo "export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
 
       # # Step 4: Disable MATLAB OpenSSL Libraries

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -224,7 +224,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
-          conda install numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4 openssl=3.0.0
+          conda install numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4
           # conda install netcdf4 hdf5
           # export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
 
@@ -350,11 +350,13 @@ jobs:
         run: brew install openssl
 
       # Step 3: Set DYLD_LIBRARY_PATH for Python's OpenSSL
-      - name: Configure DYLD_LIBRARY_PATH for MATLAB
+      # - name: Configure DYLD_LIBRARY_PATH for MATLAB
+      - name: Configure OpenSSL for MacOS/MATLAB
         if: matrix.os == 'macos-13'
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
+          conda install openssl=="3.0.*"
           # OPENSSL_LIB_PATH=$(brew --prefix openssl)/lib
           CONDA_LIB_PATH=$(python -c "import sys; import os; print(os.path.join(os.path.dirname(sys.executable), 'lib'))")
           # export DYLD_LIBRARY_PATH="$CONDA_LIB_PATH:$OPENSSL_LIB_PATH:$DYLD_LIBRARY_PATH"

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -358,13 +358,13 @@ jobs:
           export DYLD_LIBRARY_PATH="$CONDA_LIB_PATH:$OPENSSL_LIB_PATH:$DYLD_LIBRARY_PATH"
           echo "export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
 
-      # Step 4: Disable MATLAB OpenSSL Libraries
-      - name: Disable MATLAB OpenSSL Libraries
-        if: matrix.os == 'macos-13'
-        run: |
-          MATLABROOT=$(matlab -batch "disp(matlabroot)" | tail -1)
-          mv "$MATLABROOT/bin/maci64/libcrypto.3.dylib" "$MATLABROOT/bin/maci64/libcrypto.3.dylib.bak"
-          mv "$MATLABROOT/bin/maci64/libssl.3.dylib" "$MATLABROOT/bin/maci64/libssl.3.dylib.bak"
+      # # Step 4: Disable MATLAB OpenSSL Libraries
+      # - name: Disable MATLAB OpenSSL Libraries
+      #   if: matrix.os == 'macos-13'
+      #   run: |
+      #     MATLABROOT=$(matlab -batch "disp(matlabroot)" | tail -1)
+      #     mv "$MATLABROOT/bin/maci64/libcrypto.3.dylib" "$MATLABROOT/bin/maci64/libcrypto.3.dylib.bak"
+      #     mv "$MATLABROOT/bin/maci64/libssl.3.dylib" "$MATLABROOT/bin/maci64/libssl.3.dylib.bak"
 
       - name: Add Python Dir to Path
         shell: bash -l {0}

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -346,12 +346,12 @@ jobs:
           release: ${{ matrix.matlab-version }}
 
       - name: Install OpenSSL
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-13'
         run: brew install openssl
 
       # Step 3: Set DYLD_LIBRARY_PATH for Python's OpenSSL
       - name: Configure DYLD_LIBRARY_PATH for MATLAB
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-13'
         run: |
           OPENSSL_LIB_PATH=$(brew --prefix openssl)/lib
           CONDA_LIB_PATH=$(python -c "import sys; import os; print(os.path.join(os.path.dirname(sys.executable), 'lib'))")
@@ -360,7 +360,7 @@ jobs:
 
       # Step 4: Disable MATLAB OpenSSL Libraries
       - name: Disable MATLAB OpenSSL Libraries
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-13'
         run: |
           MATLABROOT=$(matlab -batch "disp(matlabroot)" | tail -1)
           mv "$MATLABROOT/bin/maci64/libcrypto.3.dylib" "$MATLABROOT/bin/maci64/libcrypto.3.dylib.bak"

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -352,7 +352,9 @@ jobs:
       # Step 3: Set DYLD_LIBRARY_PATH for Python's OpenSSL
       - name: Configure DYLD_LIBRARY_PATH for MATLAB
         if: matrix.os == 'macos-13'
+        shell: bash -l {0}
         run: |
+          conda activate mhkit_conda_env
           OPENSSL_LIB_PATH=$(brew --prefix openssl)/lib
           CONDA_LIB_PATH=$(python -c "import sys; import os; print(os.path.join(os.path.dirname(sys.executable), 'lib'))")
           export DYLD_LIBRARY_PATH="$CONDA_LIB_PATH:$OPENSSL_LIB_PATH:$DYLD_LIBRARY_PATH"

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
-          conda install numpy==1.26.4 cython pip pytest hdf5 libnetcdf cftime netcdf4
+          conda install numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4
           # conda install netcdf4 hdf5
           # export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
 
@@ -224,14 +224,14 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
-          conda install numpy==1.26.4 cython pip pytest hdf5 libnetcdf cftime netcdf4
+          conda install numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4
           # conda install netcdf4 hdf5
           # export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
 
       # - name: Setup Python ${{ matrix.python-version }}
         # shell: bash -l {0}
         # run: |
-        #   conda create --name mhkit_conda_env python=${{ matrix.python-version }} numpy==1.26.4 cython pip pytest hdf5 libnetcdf cftime netcdf4 --strict-channel-priority
+        #   conda create --name mhkit_conda_env python=${{ matrix.python-version }} numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4 --strict-channel-priority
         #   conda activate mhkit_conda_env
         #   export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
         #   pip install -e . --no-deps --force-reinstall

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -345,31 +345,15 @@ jobs:
         with:
           release: ${{ matrix.matlab-version }}
 
-      - name: Install OpenSSL
-        if: matrix.os == 'macos-13'
-        run: brew install openssl
-
-      # Step 3: Set DYLD_LIBRARY_PATH for Python's OpenSSL
-      # - name: Configure DYLD_LIBRARY_PATH for MATLAB
       - name: Configure OpenSSL for MacOS/MATLAB
         if: matrix.os == 'macos-13'
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
           conda install openssl=="3.0.*"
-          # OPENSSL_LIB_PATH=$(brew --prefix openssl)/lib
           CONDA_LIB_PATH=$(python -c "import sys; import os; print(os.path.join(os.path.dirname(sys.executable), 'lib'))")
-          # export DYLD_LIBRARY_PATH="$CONDA_LIB_PATH:$OPENSSL_LIB_PATH:$DYLD_LIBRARY_PATH"
           export DYLD_LIBRARY_PATH="$CONDA_LIB_PATH:$DYLD_LIBRARY_PATH"
           echo "export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
-
-      # # Step 4: Disable MATLAB OpenSSL Libraries
-      # - name: Disable MATLAB OpenSSL Libraries
-      #   if: matrix.os == 'macos-13'
-      #   run: |
-      #     MATLABROOT=$(matlab -batch "disp(matlabroot)" | tail -1)
-      #     mv "$MATLABROOT/bin/maci64/libcrypto.3.dylib" "$MATLABROOT/bin/maci64/libcrypto.3.dylib.bak"
-      #     mv "$MATLABROOT/bin/maci64/libssl.3.dylib" "$MATLABROOT/bin/maci64/libssl.3.dylib.bak"
 
       - name: Add Python Dir to Path
         shell: bash -l {0}

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -345,6 +345,20 @@ jobs:
         with:
           release: ${{ matrix.matlab-version }}
 
+      - name: Configure Dynamic Library Paths for macOS and Ubuntu
+        shell: bash -l {0}
+        run: |
+          conda activate mhkit_conda_env
+          CONDA_LIB_PATH=$(python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
+          CONDA_PREFIX=$(conda info --base)
+          if [[ "$(uname)" == "Darwin" ]]; then
+            export DYLD_LIBRARY_PATH="$CONDA_LIB_PATH:$CONDA_PREFIX/envs/mhkit_conda_env/lib:$DYLD_LIBRARY_PATH"
+            echo "export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
+          else
+            export LD_LIBRARY_PATH="$CONDA_LIB_PATH:$CONDA_PREFIX/envs/mhkit_conda_env/lib:$LD_LIBRARY_PATH"
+            echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          fi
+
       - name: Add Python Dir to Path
         shell: bash -l {0}
         run: |
@@ -357,6 +371,15 @@ jobs:
         run: |
           conda activate mhkit_conda_env
           printf 'pyenv(Version="%s", ExecutionMode="OutOfProcess")\n' $(python -c "import sys; print(sys.executable)") >> run.m
+          # Pass dynamic library paths to MATLAB
+          echo "setenv('DYLD_LIBRARY_PATH', getenv('DYLD_LIBRARY_PATH'));" >> run.m
+          echo "setenv('LD_LIBRARY_PATH', getenv('LD_LIBRARY_PATH'));" >> run.m
+
+      # - name: Configure MATLAB Python Environment
+      #   shell: bash -l {0}
+      #   run: |
+      #     conda activate mhkit_conda_env
+      #     printf 'pyenv(Version="%s", ExecutionMode="OutOfProcess")\n' $(python -c "import sys; print(sys.executable)") >> run.m
 
       - name: Add MATLAB test commands
         shell: bash

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -36,24 +36,9 @@ jobs:
         run: |
           conda activate mhkit_conda_env
           conda install numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4
-          # conda install netcdf4 hdf5
-          # export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
 
       - name: Check out MHKiT-MATLAB
         uses: actions/checkout@v4
-
-      # - name: Check out MHKiT-Python
-      #   uses: actions/checkout@v4
-      #   with:
-      #     repository: "MHKiT-Software/MHKiT-Python"
-      #     path: ${{env.mhkit-python-dir}}
-
-      # - name: pip install mhkit module from source
-      #   shell: bash -l {0}
-      #   run: |
-      #     conda activate mhkit_conda_env
-      #     pip install -e .
-      #   working-directory: ${{env.mhkit-python-dir}}
 
       - name: pip install mhkit from pypi
         shell: bash -l {0}
@@ -204,12 +189,6 @@ jobs:
       - name: Check out MHKiT-MATLAB
         uses: actions/checkout@v4
 
-      # - name: Check out MHKiT-Python
-      #   uses: actions/checkout@v4
-      #   with:
-      #     repository: "MHKiT-Software/MHKiT-Python"
-      #     path: ${{env.mhkit-python-dir}}
-
       - name: Install & Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -225,41 +204,6 @@ jobs:
         run: |
           conda activate mhkit_conda_env
           conda install numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4
-          # conda install netcdf4 hdf5
-          # export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
-
-      # - name: Setup Python ${{ matrix.python-version }}
-        # shell: bash -l {0}
-        # run: |
-        #   conda create --name mhkit_conda_env python=${{ matrix.python-version }} numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4 --strict-channel-priority
-        #   conda activate mhkit_conda_env
-        #   export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
-        #   pip install -e . --no-deps --force-reinstall
-
-      # - name: Setup MHKiT Dependencies on macOS
-      #   if: ${{ matrix.os == 'macos-13' }}
-      #   run: brew install hdf5 netcdf
-
-      # - name: Setup MHKiT Dependencies on ubuntu
-      #   run: sudo apt install libhdf5-serial-dev libnetcdf-dev
-      #   if: ${{ matrix.os == 'ubuntu-latest' }}
-
-      # - name: Setup MHKiT Dependencies on ubuntu
-      #   if: ${{ matrix.os == 'ubuntu-latest' }}
-      #   run: |
-      #     sudo apt update
-      #     sudo apt upgrade
-      #     sudo apt install build-essential
-
-      # - name: Print GCC Version
-      #   if: ${{ matrix.os == 'ubuntu-latest' }}
-      #   run: |
-      #     gcc --version
-      #     g++ --version
-
-      # - name: Setup MATLAB Path on Ubuntu
-      #   if: ${{ matrix.os == 'ubuntu-latest' }}
-      #   run: echo "export LD_LIBRARY_PATH=/usr/local/MATLAB/${{ matrix.matlab-version }}/sys/os/glnxa64" >> "$GITHUB_ENV"
 
       - name: Setup MATLAB Path on Ubuntu
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -276,14 +220,6 @@ jobs:
         run: |
           conda activate mhkit_conda_env
           python --version
-
-      # - name: pip install mhkit module from source
-      #   working-directory: ${{env.mhkit-python-dir}}
-      #   shell: bash -l {0}
-      #   run: |
-      #     conda activate mhkit_conda_env
-      #     export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
-      #     pip install -e .
 
       - name: pip install mhkit from pypi
         shell: bash -l {0}
@@ -371,12 +307,6 @@ jobs:
           if [[ $OSTYPE == "darwin"* ]]; then
             echo "setenv('DYLD_LIBRARY_PATH', getenv('DYLD_LIBRARY_PATH'));" >> run.m
           fi
-
-      # - name: Configure MATLAB Python Environment
-      #   shell: bash -l {0}
-      #   run: |
-      #     conda activate mhkit_conda_env
-      #     printf 'pyenv(Version="%s", ExecutionMode="OutOfProcess")\n' $(python -c "import sys; print(sys.executable)") >> run.m
 
       - name: Add MATLAB test commands
         shell: bash

--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -224,7 +224,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
-          conda install numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4 openssl
+          conda install numpy==1.24.4 cython pip pytest hdf5 libnetcdf cftime netcdf4
           # conda install netcdf4 hdf5
           # export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" # so setup.py finds nc-config
 
@@ -345,19 +345,26 @@ jobs:
         with:
           release: ${{ matrix.matlab-version }}
 
-      - name: Configure Dynamic Library Paths for macOS and Ubuntu
-        shell: bash -l {0}
+      - name: Install OpenSSL
+        if: matrix.os == 'macos-latest'
+        run: brew install openssl
+
+      # Step 3: Set DYLD_LIBRARY_PATH for Python's OpenSSL
+      - name: Configure DYLD_LIBRARY_PATH for MATLAB
+        if: matrix.os == 'macos-latest'
         run: |
-          conda activate mhkit_conda_env
-          CONDA_LIB_PATH=$(python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
-          CONDA_PREFIX=$(conda info --base)
-          if [[ "$(uname)" == "Darwin" ]]; then
-            export DYLD_LIBRARY_PATH="$CONDA_LIB_PATH:$CONDA_PREFIX/envs/mhkit_conda_env/lib:$DYLD_LIBRARY_PATH"
-            echo "export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
-          else
-            export LD_LIBRARY_PATH="$CONDA_LIB_PATH:$CONDA_PREFIX/envs/mhkit_conda_env/lib:$LD_LIBRARY_PATH"
-            echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
-          fi
+          OPENSSL_LIB_PATH=$(brew --prefix openssl)/lib
+          CONDA_LIB_PATH=$(python -c "import sys; import os; print(os.path.join(os.path.dirname(sys.executable), 'lib'))")
+          export DYLD_LIBRARY_PATH="$CONDA_LIB_PATH:$OPENSSL_LIB_PATH:$DYLD_LIBRARY_PATH"
+          echo "export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
+
+      # Step 4: Disable MATLAB OpenSSL Libraries
+      - name: Disable MATLAB OpenSSL Libraries
+        if: matrix.os == 'macos-latest'
+        run: |
+          MATLABROOT=$(matlab -batch "disp(matlabroot)" | tail -1)
+          mv "$MATLABROOT/bin/maci64/libcrypto.3.dylib" "$MATLABROOT/bin/maci64/libcrypto.3.dylib.bak"
+          mv "$MATLABROOT/bin/maci64/libssl.3.dylib" "$MATLABROOT/bin/maci64/libssl.3.dylib.bak"
 
       - name: Add Python Dir to Path
         shell: bash -l {0}
@@ -371,9 +378,10 @@ jobs:
         run: |
           conda activate mhkit_conda_env
           printf 'pyenv(Version="%s", ExecutionMode="OutOfProcess")\n' $(python -c "import sys; print(sys.executable)") >> run.m
-          # Pass dynamic library paths to MATLAB
-          echo "setenv('DYLD_LIBRARY_PATH', getenv('DYLD_LIBRARY_PATH'));" >> run.m
-          echo "setenv('LD_LIBRARY_PATH', getenv('LD_LIBRARY_PATH'));" >> run.m
+          # Pass dynamic library paths to MATLAB only on macOS
+          if [[ $OSTYPE == "darwin"* ]]; then
+            echo "setenv('DYLD_LIBRARY_PATH', getenv('DYLD_LIBRARY_PATH'));" >> run.m
+          fi
 
       # - name: Configure MATLAB Python Environment
       #   shell: bash -l {0}

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "Conda install netcdf4, hdf5"
         run: |
           conda activate mhkit_conda_env
-          conda install numpy==1.24.4 netcdf4 hdf5
+          conda install numpy==1.26.4 netcdf4 hdf5
       - name: Check out MHKiT-MATLAB
         uses: actions/checkout@v4
 
@@ -180,7 +180,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
-          conda install numpy==1.24.4 netcdf4 hdf5
+          conda install numpy==1.26.4 netcdf4 hdf5
       - name: Output python executable
         shell: bash -l {0}
         run: |

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -37,18 +37,6 @@ jobs:
       - name: Check out MHKiT-MATLAB
         uses: actions/checkout@v4
 
-      # - name: Check out MHKiT-Python
-      #   uses: actions/checkout@v4
-      #   with:
-      #     repository: "MHKiT-Software/MHKiT-Python"
-      #     path: ${{env.mhkit-python-dir}}
-
-      # - name: pip install mhkit from source
-      #   working-directory: ${{env.mhkit-python-dir}}
-      #   run: |
-      #     conda activate mhkit_conda_env
-      #     pip3 install -e .
-
       - name: pip install mhkit from pypi
         shell: bash -l {0}
         run: |
@@ -193,18 +181,6 @@ jobs:
           python --version
       - name: Check out MHKiT-MATLAB
         uses: actions/checkout@v4
-
-      # - name: Check out MHKiT-Python
-      #   uses: actions/checkout@v4
-      #   with:
-      #     repository: "MHKiT-Software/MHKiT-Python"
-      #     path: ${{env.mhkit-python-dir}}
-
-      # - name: pip install mhkit from source
-      #   working-directory: ${{env.mhkit-python-dir}}
-      #   run: |
-      #     conda activate mhkit_conda_env
-      #     pip3 install -e .
 
       - name: pip install mhkit from pypi
         shell: bash -l {0}

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "Conda install netcdf4, hdf5"
         run: |
           conda activate mhkit_conda_env
-          conda install numpy==1.26.4 netcdf4 hdf5
+          conda install numpy==1.24.4 netcdf4 hdf5
       - name: Check out MHKiT-MATLAB
         uses: actions/checkout@v4
 
@@ -180,7 +180,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate mhkit_conda_env
-          conda install numpy==1.26.4 netcdf4 hdf5
+          conda install numpy==1.24.4 netcdf4 hdf5
       - name: Output python executable
         shell: bash -l {0}
         run: |

--- a/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
+++ b/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
@@ -23,10 +23,11 @@ end
 
     python_result = py.mhkit.river.io.d3d.get_all_time(delft_3d_py_object);
 
+    disp(python_result);
+
     python_result = py.numpy.ndarray(python_result);
 
-disp(python_result);
-disp(class(python_result));
+    disp(python_result);
 
 result = double(python_result);
 end

--- a/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
+++ b/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
@@ -23,5 +23,8 @@ function result = delft_3d_get_all_time(delft_3d_py_object)
 
     python_result = py.mhkit.river.io.d3d.get_all_time(delft_3d_py_object);
 
+    disp(python_result);
+    disp(class(python_result));
+
     result = double(python_result);
 end

--- a/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
+++ b/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
@@ -23,5 +23,17 @@ end
 
     python_result = py.mhkit.river.io.d3d.get_all_time(delft_3d_py_object);
 
-    result = double(py.list(python_result));
+    % Handle masked arrays using numpy.ma.getdata
+    if isa(python_result, 'py.numpy.ma.MaskedArray')
+        % Extract the underlying data
+        data_array = py.numpy.ma.getdata(python_result);
+    else
+        % Convert directly if not masked
+        data_array = py.numpy.array(python_result);
+    end
+
+    % Ensure data is of type float
+    float_array = data_array.astype('float');
+
+    result = double(float_array);
 end

--- a/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
+++ b/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
@@ -16,15 +16,17 @@ function result = delft_3d_get_all_time(delft_3d_py_object)
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-    if ~isa(delft_3d_py_object, 'py.netCDF4._netCDF4.Dataset')
-        error('MATLAB:delft_3d_get_all_time:InvalidInput', ...
-              'Invalid input Delft3D data type: `delft_3d_get_all_time` expects a `py.netCDF4._netCDF4.Dataset` object. Please use the `delft_3d_open_netcdf` function to convert Delft3D netCDF files for use with this function.');
-    end
+if ~isa(delft_3d_py_object, 'py.netCDF4._netCDF4.Dataset')
+    error('MATLAB:delft_3d_get_all_time:InvalidInput', ...
+        'Invalid input Delft3D data type: `delft_3d_get_all_time` expects a `py.netCDF4._netCDF4.Dataset` object. Please use the `delft_3d_open_netcdf` function to convert Delft3D netCDF files for use with this function.');
+end
 
-    python_result = py.mhkit.river.io.d3d.get_all_time(delft_3d_py_object);
+python_result = py.mhkit.river.io.d3d.get_all_time(delft_3d_py_object);
 
-    disp(python_result);
-    disp(class(python_result));
+python_result = python_result.to_list();
 
-    result = double(python_result);
+disp(python_result);
+disp(class(python_result));
+
+result = double(python_result);
 end

--- a/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
+++ b/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
@@ -23,6 +23,8 @@ end
 
     python_result = py.mhkit.river.io.d3d.get_all_time(delft_3d_py_object);
 
+    disp(class(python_result));
+    disp(python_result.shape);
     disp(python_result);
 
     python_result = py.numpy.ndarray(python_result);

--- a/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
+++ b/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
@@ -23,9 +23,6 @@ end
 
     python_result = py.mhkit.river.io.d3d.get_all_time(delft_3d_py_object);
 
-    disp(class(python_result));
-    disp(python_result.shape);
-    disp(python_result);
 
     python_result = py.numpy.ndarray(python_result);
 

--- a/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
+++ b/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
@@ -23,10 +23,5 @@ end
 
     python_result = py.mhkit.river.io.d3d.get_all_time(delft_3d_py_object);
 
-
-    python_result = py.numpy.ndarray(python_result);
-
-    disp(python_result);
-
-result = double(python_result);
+    result = double(python_result);
 end

--- a/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
+++ b/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
@@ -21,9 +21,9 @@ if ~isa(delft_3d_py_object, 'py.netCDF4._netCDF4.Dataset')
         'Invalid input Delft3D data type: `delft_3d_get_all_time` expects a `py.netCDF4._netCDF4.Dataset` object. Please use the `delft_3d_open_netcdf` function to convert Delft3D netCDF files for use with this function.');
 end
 
-python_result = py.mhkit.river.io.d3d.get_all_time(delft_3d_py_object);
+    python_result = py.mhkit.river.io.d3d.get_all_time(delft_3d_py_object);
 
-python_result = python_result.to_list();
+    python_result = py.list(python_result);
 
 disp(python_result);
 disp(class(python_result));

--- a/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
+++ b/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
@@ -23,5 +23,5 @@ end
 
     python_result = py.mhkit.river.io.d3d.get_all_time(delft_3d_py_object);
 
-    result = double(python_result);
+    result = double(py.list(python_result));
 end

--- a/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
+++ b/mhkit/river/IO/delft_3d/delft_3d_get_all_time.m
@@ -23,7 +23,7 @@ end
 
     python_result = py.mhkit.river.io.d3d.get_all_time(delft_3d_py_object);
 
-    python_result = py.list(python_result);
+    python_result = py.numpy.ndarray(python_result);
 
 disp(python_result);
 disp(class(python_result));


### PR DESCRIPTION
# Windows Failing Tests

* `river` functions that call `delft_3d_get_all_time`, on python 3.10, all matlab versions, mhkit-python 0.7.0.

```
Running River_TestIO_Delft
  ...
  ================================================================================
  Error occurred in River_TestIO_Delft/testGetAllTime and it did not run to completion.
      ---------
      Error ID:
      ---------
      'MATLAB:Python:ConverterError'
      --------------
      Error Details:
      --------------
      Error using py.numpy.ndarray/double
      Conversion of Python 'ndarray' type to MATLAB 'double' is only supported for real numbers and logicals.

      Error in delft_3d_get_all_time (line 26)
          result = double(python_result);

      Error in River_TestIO_Delft/testGetAllTime (line 37)
                  time = delft_3d_get_all_time(data);
```

Attempted fixes:

* Update numpy to 1.26.4
  * No change
* Convert output of d3d.get_all_time to a python list then convert to double

# Working fix: 

* Convert np masked array to np array in `delft_3d_get_all_time`: https://github.com/MHKiT-Software/MHKiT-MATLAB/pull/148/commits/f7b6e7c2d243426ac0d09fc96e68946e8431cc02

# Unix Failing Tests

```
Error using ssl><module> (line 99)
      Python Error: ImportError:
      dlopen(/Users/runner/miniconda3/envs/mhkit_conda_env/lib/python3.9/lib-dynload/_ssl.cpython-39-darwin.so,
      0x0002): Symbol not found: _X509_STORE_get1_objects
        Referenced from: <DEADD0A1-08C8-3D77-A19C-08827189D194>
        /Users/runner/miniconda3/envs/mhkit_conda_env/lib/python3.9/lib-dynload/_ssl.cpython-39-darwin.so
            Expected in:     <F5E6CE2E-D06E-3F50-8C70-5B9602FE418A>
        /Users/runner/hostedtoolcache/MATLAB/2024.1.999/x64/MATLAB.app/bin/maci64/libcrypto.3.dylib
```

Starting point:
  * Failing:
    * Macos:
      * 3.9, R2023b
      * 3.9 R2024a
      * 3.10 R2023b
      * 3.10 R2024a
      * 3.11 R2023b
      * 3.11 R2024a 


Attempted Fixes:

* Modify dynamic library paths: [b7ce780](https://github.com/MHKiT-Software/MHKiT-MATLAB/pull/148/commits/b7ce7802f8b7eb8c6d60565fb7af48ec24d2cc9c)


Working Fix:

* Install specific openssl version, `3.0.*` with conda and add it as the first entry in `DYLD_LIBRARY_PATH`: https://github.com/MHKiT-Software/MHKiT-MATLAB/pull/148/commits/2ae226e1b86aa5ca61fe4cbf64c6416c472ad748
